### PR TITLE
Patched zmq uri string connect

### DIFF
--- a/src/DabMod.cpp
+++ b/src/DabMod.cpp
@@ -664,7 +664,7 @@ int main(int argc, char* argv[])
         ret = -1;
         goto END_MAIN;
 #else
-        inputZeroMQReader.Open(inputName);
+        inputZeroMQReader.Open(inputName.substr(4));
         inputReader = &inputZeroMQReader;
 #endif
     }


### PR DESCRIPTION
HI
if zmq input is specified in command line (odr-dabmod -f /dev/stdout zmq+tcp://127.0.0.1:9999) the full string  zmq+tcp://127.0.0.1:9999 is passed to subscriber.connect and zmq exception occurs:
ZeroMQ error in RecvProcess: 'Protocol not supported'

Regards
Sergio
