### PR TITLE
Changed scaling factor to avoid clipping when gain is 1.0

### DIFF
--- a/src/DabMod.cpp
+++ b/src/DabMod.cpp
@@ -684,7 +684,7 @@ int main(int argc, char* argv[])
     }
 #if defined(HAVE_OUTPUT_UHD)
     else if (useUHDOutput) {
-        normalise = 1.0f/48764.0f;
+        normalise = 1.0f/50000.0f;
         outputuhd_conf.sampleRate = outputRate;
         try {
             output = new OutputUHD(outputuhd_conf, logger);


### PR DESCRIPTION
When samples go over [-1;+1], UHD clip them. This degrades the signal and create wideband transient.
The scaling factor has been adjusted from 1/32768 to 1/48764 after measurement on output samples when filter is enabled and gain is 1.0
