### PR TITLE
Made some changes

### DIFF
--- a/doc/zmq-ctrl/cpp/OdrModCtrl.cpp
+++ b/doc/zmq-ctrl/cpp/OdrModCtrl.cpp
@@ -51,6 +51,7 @@ COdrModCtrl::COdrModCtrl(zmq::context_t *pContext, std::string odrEndpoint,
 	m_pContext = pContext;
 	m_odrEndpoint = odrEndpoint;
 	m_timeoutMs = (uint32_t) timeoutMs;
+	m_pReqSocket = NULL;
 }
 
 COdrModCtrl::~COdrModCtrl()

--- a/src/RemoteControl.cpp
+++ b/src/RemoteControl.cpp
@@ -308,7 +308,7 @@ void RemoteControllerZmq::process()
 {
     // create zmq reply socket for receiving ctrl parameters
     zmq::socket_t repSocket(m_zmqContext, ZMQ_REP);
-    std::cout << "Starting zmq remote control thread" << std::endl;
+    std::cerr << "Starting zmq remote control thread" << std::endl;
     try
     {
         // connect the socket
@@ -342,10 +342,9 @@ void RemoteControllerZmq::process()
                     try
                     {
                         std::string value = get_param_(module, parameter);
-                        zmq::message_t *pMsg = new zmq::message_t(value.size());
-                        memcpy ((void*) pMsg->data(), value.data(), value.size());
-                        repSocket.send(*pMsg, 0);
-                        delete pMsg;
+                        zmq::message_t msg(value.size());
+                        memcpy ((void*) msg.data(), value.data(), value.size());
+                        repSocket.send(&msg, 0);
                     }
                     catch (ParameterError &err)
                     {


### PR DESCRIPTION
Hi Mattias,

I've made some changes according to our mail discussion. I remembered now why I made the zmq ctrl thread polling for abort condition, it keeps the zmq ctrl aligned with the Telnet ctrl that also use the boost thread interrupt so I kept it as is.

As for memory leaks, I can't really comment except that I have not noticed any.