### PR TITLE
Fix SAD field width

### DIFF
--- a/src/SubchannelSource.cpp
+++ b/src/SubchannelSource.cpp
@@ -67,7 +67,7 @@ const std::vector<PuncturingRule>& SubchannelSource::get_rules() const
 
 
 SubchannelSource::SubchannelSource(
-            uint8_t sad,
+            uint16_t sad,
             uint16_t stl,
             uint8_t tpl
             ) :

--- a/src/SubchannelSource.h
+++ b/src/SubchannelSource.h
@@ -42,7 +42,7 @@ class SubchannelSource : public ModInput
 {
 public:
     SubchannelSource(
-            uint8_t sad,
+            uint16_t sad,
             uint16_t stl,
             uint8_t tpl
             );


### PR DESCRIPTION
The width of the SAD field is 10bit, therefore up to now subchannels with a
higher start address were by mistake placed at a lower address within the MSC.
Thereby also other subchannels could have been overwritten.