### PR TITLE
Fix compiler warning strncpy

### DIFF
--- a/lib/INIReader.h
+++ b/lib/INIReader.h
@@ -178,7 +178,7 @@ inline static char* find_chars_or_comment(const char* s, const char* chars)
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */
 inline static char* strncpy0(char* dest, const char* src, size_t size)
 {
-    strncpy(dest, src, size - 1);
+    strncpy0(dest, src, size - 1);
     dest[size - 1] = '\0';
     return dest;
 }


### PR DESCRIPTION
The warning 

```
...
  CXX      src/odr_dabmod-ConfigParser.o
In file included from /usr/include/string.h:495,
                 from lib/INIReader.h:132,
                 from src/ConfigParser.cpp:35:
In function ‘char* strncpy(char*, const char*, size_t)’,
    inlined from ‘char* strncpy0(char*, const char*, size_t)’ at lib/INIReader.h:181:12,
    inlined from ‘int ini_parse_stream(ini_reader, void*, ini_handler, void*)’ at lib/INIReader.h:275:25,
    inlined from ‘int ini_parse_file(FILE*, ini_handler, void*)’ at lib/INIReader.h:301:28,
    inlined from ‘int ini_parse(const char*, ini_handler, void*)’ at lib/INIReader.h:313:27,
    inlined from ‘INIReader::INIReader(std::string)’ at lib/INIReader.h:388:23,
    inlined from ‘void parse_configfile(const string&, mod_settings_t&)’ at src/ConfigParser.cpp:72:36:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:34: warning: ‘char* __builtin_strncpy(char*, const char*, long unsigned int)’ output may be truncated copying 49 bytes from a string of length 199 [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  CXX      src/odr_dabmod-ModPlugin.o
...  
```

will disapprear in Linux and in Cygwin

```
$ LANG=en_GB make
make  all-am
make[1]: Entering directory '/home/andreas/apps/ODR-DabMod'
  CXX      src/odr_dabmod-DabMod.o
  CXX      src/odr_dabmod-DabModulator.o
  CXX      src/odr_dabmod-Buffer.o
  CXX      src/odr_dabmod-ConfigParser.o
  CXX      src/odr_dabmod-ModPlugin.o
  CXX      src/odr_dabmod-EtiReader.o
  CXX      src/odr_dabmod-Eti.o
  CXX      src/odr_dabmod-FicSource.o
  CXX      src/odr_dabmod-PuncturingRule.o
  CXX      src/odr_dabmod-PuncturingEncoder.o
  CXX      src/odr_dabmod-SubchannelSource.o
  CXX      src/odr_dabmod-Flowgraph.o
  CXX      src/odr_dabmod-OutputMemory.o
  CXX      src/odr_dabmod-OutputZeroMQ.o
  CXX      src/odr_dabmod-TimestampDecoder.o
  CXX      src/odr_dabmod-InputFileReader.o
  CXX      src/odr_dabmod-InputMemory.o
  CXX      src/odr_dabmod-InputTcpReader.o
  CXX      src/odr_dabmod-InputZeroMQReader.o
  CXX      src/odr_dabmod-OutputFile.o
  CXX      src/odr_dabmod-FrameMultiplexer.o
  CXX      src/odr_dabmod-PrbsGenerator.o
  CXX      src/odr_dabmod-BlockPartitioner.o
  CXX      src/odr_dabmod-SignalMultiplexer.o
  CXX      src/odr_dabmod-ConvEncoder.o
  CXX      src/odr_dabmod-TimeInterleaver.o
  CXX      src/odr_dabmod-FormatConverter.o
  CXX      src/odr_dabmod-Utils.o
  CXX      lib/odr_dabmod-RemoteControl.o
  CXX      lib/odr_dabmod-Log.o
  CXX      lib/odr_dabmod-Globals.o
  CC       lib/odr_dabmod-crc.o
  CXX      lib/odr_dabmod-Socket.o
  CC       lib/fec/odr_dabmod-decode_rs_char.o
  CC       lib/fec/odr_dabmod-encode_rs_char.o
  CC       lib/fec/odr_dabmod-init_rs_char.o
  CXX      lib/edi/odr_dabmod-common.o
  CXX      lib/edi/odr_dabmod-eti.o
  CXX      lib/edi/odr_dabmod-ETIDecoder.o
  CXX      lib/edi/odr_dabmod-PFT.o
  CXX      src/odr_dabmod-FIRFilter.o
  CXX      src/odr_dabmod-MemlessPoly.o
  CXX      src/odr_dabmod-GainControl.o
  CXX      src/output/odr_dabmod-Feedback.o
  CXX      src/output/odr_dabmod-SDR.o
  CXX      src/output/odr_dabmod-Soapy.o
  CXX      src/output/odr_dabmod-UHD.o
  CXX      src/output/odr_dabmod-USRPTime.o
  CXX      src/output/odr_dabmod-Lime.o
  CXX      src/odr_dabmod-PhaseReference.o
  CXX      src/odr_dabmod-QpskSymbolMapper.o
  CXX      src/odr_dabmod-FrequencyInterleaver.o
  CXX      src/odr_dabmod-DifferentialModulator.o
  CXX      src/odr_dabmod-NullSymbol.o
  CXX      src/odr_dabmod-CicEqualizer.o
  CXX      src/odr_dabmod-OfdmGenerator.o
  CXX      src/odr_dabmod-GuardIntervalInserter.o
  CXX      src/odr_dabmod-Resampler.o
  CXX      src/odr_dabmod-PAPRStats.o
  CXX      src/odr_dabmod-TII.o
  CXXLD    odr-dabmod
make[1]: Leaving directory '/home/andreas/apps/ODR-DabMod'
```