### PR TITLE
missing if for zeromq

### DIFF
--- a/lib/RemoteControl.cpp
+++ b/lib/RemoteControl.cpp
@@ -29,7 +29,9 @@
 #include <algorithm>
 
 #include "RemoteControl.h"
-#include "zmq.hpp"
+#if defined(HAVE_ZEROMQ)
+    #include "zmq.hpp"
+#endif
 
 using namespace std;
 


### PR DESCRIPTION
fixes bug from https://github.com/Opendigitalradio/ODR-DabMod/commit/d14814a92377084177753c7a60d83a9307ad0672 when zeromq is **not** configured