### PR TITLE
Hide options for UHD when not configured

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -81,11 +81,16 @@ void printUsage(const char* progName)
     fprintf(out, "Usage with command line options:\n");
     fprintf(out, "\t%s"
             " input"
-            " (-f filename -F format | -u uhddevice -F frequency)"
-            " [-o offset]"
+            " (-f filename -F format"
+#if defined(HAVE_OUTPUT_UHD)
+            " | -u uhddevice -F frequency"
+#endif  // defined(HAVE_OUTPUT_UHD)
+            ") [-o offset]"
             "\n\t"
+#if defined(HAVE_OUTPUT_UHD)
             " [-G txgain]"
             " [-T filter_taps_file]"
+#endif  // defined(HAVE_OUTPUT_UHD)
             " [-a gain]"
             " [-c clockrate]"
             "\n\t"
@@ -105,11 +110,13 @@ void printUsage(const char* progName)
     fprintf(out, "                  Specifying this option has two implications: It enables synchronous transmission,\n"
                  "                  requiring an external REFCLK and PPS signal and frames that do not contain a valid timestamp\n"
                  "                  get muted.\n\n");
+#if defined(HAVE_OUTPUT_UHD)
     fprintf(out, "-u device:     Use UHD output with given device string. (use "" for default device)\n");
     fprintf(out, "-F frequency:  Set the transmit frequency when using UHD output. (mandatory option when using UHD)\n");
     fprintf(out, "-G txgain:     Set the transmit gain for the UHD driver (default: 0)\n");
     fprintf(out, "-T taps_file:  Enable filtering before the output, using the specified file containing the filter taps.\n");
     fprintf(out, "               Use 'default' as taps_file to use the internal taps.\n");
+#endif  // defined(HAVE_OUTPUT_UHD)
     fprintf(out, "-a gain:       Apply digital amplitude gain.\n");
     fprintf(out, "-c rate:       Set the DAC clock rate and enable Cic Equalisation.\n");
     fprintf(out, "-g gainmode:   Set computation gain mode: fix, max or var\n");


### PR DESCRIPTION
# Before

```
odr-dabmod --help
ODR-DabMod version v2.6.0, compiled at Oct  4 2024, 09:54:07
Compiled with features: output_soapysdr SSE 
odr-dabmod: invalid option -- '-'
Usage with configuration file:
	odr-dabmod config_file.ini

Usage with command line options:
	odr-dabmod input (-f filename -F format | -u uhddevice -F frequency) [-o offset]
	 [-G txgain] [-T filter_taps_file] [-a gain] [-c clockrate]
	 [-g gainMode] [-m dabMode] [-r samplingRate] [-l] [-h]
Where:
input:         ETI input filename (default: stdin), or
                  tcp://source:port for ETI-over-TCP input, or
                  zmq+tcp://source:port for ZMQ input.
                  udp://:port for EDI input.
-f name:       Use file output with given filename. (use /dev/stdout for standard output)
-F format:     Set the output format (see doc/example.ini for formats) for the file output.
-o:            Set the timestamp offset added to the timestamp in the ETI. The offset is a double.
                  Specifying this option has two implications: It enables synchronous transmission,
                  requiring an external REFCLK and PPS signal and frames that do not contain a valid timestamp
                  get muted.

-u device:     Use UHD output with given device string. (use  for default device)
-F frequency:  Set the transmit frequency when using UHD output. (mandatory option when using UHD)
-G txgain:     Set the transmit gain for the UHD driver (default: 0)
-T taps_file:  Enable filtering before the output, using the specified file containing the filter taps.
               Use 'default' as taps_file to use the internal taps.
-a gain:       Apply digital amplitude gain.
-c rate:       Set the DAC clock rate and enable Cic Equalisation.
-g gainmode:   Set computation gain mode: fix, max or var
-m mode:       Set DAB mode: (0: auto, 1-4: force).
-r rate:       Set output sampling rate (default: 2048000).

-l:            Loop file when reach end of file.
-h:            Print this help.
```

# After

```
./odr-dabmod 
ODR-DabMod version v2.6.0-113-gc13b993-dirty, compiled at Nov 26 2024, 18:24:52
Compiled with features: output_soapysdr fast-math SSE 
Usage with configuration file:
	./odr-dabmod config_file.ini

Usage with command line options:
	./odr-dabmod input (-f filename -F format) [-o offset]
	 [-a gain] [-c clockrate]
	 [-g gainMode] [-m dabMode] [-r samplingRate] [-l] [-h]
Where:
input:         ETI input filename (default: stdin), or
                  tcp://source:port for ETI-over-TCP input, or
                  udp://:port for EDI input.
-f name:       Use file output with given filename. (use /dev/stdout for standard output)
-F format:     Set the output format (see doc/example.ini for formats) for the file output.
-o:            Set the timestamp offset added to the timestamp in the ETI. The offset is a double.
                  Specifying this option has two implications: It enables synchronous transmission,
                  requiring an external REFCLK and PPS signal and frames that do not contain a valid timestamp
                  get muted.

-a gain:       Apply digital amplitude gain.
-c rate:       Set the DAC clock rate and enable Cic Equalisation.
-g gainmode:   Set computation gain mode: fix, max or var
-m mode:       Set DAB mode: (0: auto, 1-4: force).
-r rate:       Set output sampling rate (default: 2048000).

-l:            Loop file when reach end of file.
-h:            Print this help.
Modulator error: Invalid command line options
```