### PR TITLE
French comment translated to English

### DIFF
--- a/src/Eti.h
+++ b/src/Eti.h
@@ -44,8 +44,7 @@ typedef DWORD32 uint32_t;
 
 #include <time.h>
 
-//definitions des structures des champs du ETI(NI, G703)
-
+// Definitions of the structures for the fields of ETI (NI, G703)
 
 struct eti_SYNC {
     uint32_t ERR:8;


### PR DESCRIPTION
By chance, I found this French comment in the code and translated it to English.

Github Pilot says, there are no other French texts.

> All other comments in the matched files are either in English or are standard copyright/license headers. No further French comments were detected.